### PR TITLE
feat: Show splashscreen when application goes to background and discriminate show/hide by name

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.bridge.PromiseImpl;
 
 import java.util.ArrayList;
 import java.util.Timer;
@@ -93,7 +94,9 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
 
   @Override
   public void onHostPause() {
-    mIsAppInBackground = true;
+    Promise promise = new PromiseImpl(null, null);
+    mTaskQueue.add(new RNBootSplashTask(RNBootSplashTask.Type.SHOW, false, promise));
+    shiftNextTask();
   }
 
   @Override

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashTask.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashTask.java
@@ -12,19 +12,26 @@ public class RNBootSplashTask {
   }
 
   private final boolean mFade;
+  private final String mBootsplashName;
   @NonNull private final Promise mPromise;
   @NonNull private final Type mType;
 
   public RNBootSplashTask(@NonNull Type type,
                           boolean fade,
+                          String bootsplashName,
                           @NonNull Promise promise) {
     mType = type;
     mFade = fade;
+    mBootsplashName = bootsplashName;
     mPromise = promise;
   }
 
   public boolean getFade() {
     return mFade;
+  }
+
+  public String getBootsplashName() {
+    return mBootsplashName;
   }
 
   @NonNull

--- a/ios/RNBootSplash.h
+++ b/ios/RNBootSplash.h
@@ -17,11 +17,13 @@ typedef enum {
 
 @property (nonatomic, readonly) RNBootSplashTaskType type;
 @property (nonatomic, readonly) BOOL fade;
+@property (nonatomic, readonly) NSString* bootsplashName;
 @property (nonatomic, readonly, strong) RCTPromiseResolveBlock _Nonnull resolve;
 @property (nonatomic, readonly, strong) RCTPromiseRejectBlock _Nonnull reject;
 
 - (instancetype _Nonnull)initWithType:(RNBootSplashTaskType)type
                                  fade:(BOOL)fade
+                       bootsplashName:(NSString *)bootsplashName
                              resolver:(RCTPromiseResolveBlock _Nonnull)resolve
                              rejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 
@@ -31,5 +33,8 @@ typedef enum {
 
 + (void)initWithStoryboard:(NSString * _Nonnull)storyboardName
                   rootView:(RCTRootView * _Nonnull)rootView;
++ (void)addBootsplashName:(NSString * _Nonnull)name;
++ (void)removeBootsplashName:(NSString * _Nonnull)name;
++ (BOOL)hasBootsplashToDisplay;
 
 @end

--- a/ios/RNBootSplash.m
+++ b/ios/RNBootSplash.m
@@ -80,6 +80,10 @@ RCT_EXPORT_MODULE();
                                            selector:@selector(shiftNextTask)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(applicationWillResignActive)
+                                               name:UIApplicationWillResignActiveNotification
+                                             object:nil];
 }
 
 + (void)onJavaScriptDidLoad:(NSNotification *)notification {
@@ -161,6 +165,17 @@ RCT_EXPORT_MODULE();
       [self shiftNextTask];
     }];
   }
+}
+
++ (void)applicationWillResignActive
+{
+    RNBootSplashTask *task = [[RNBootSplashTask alloc] initWithType:RNBootSplashTaskTypeShow
+                                                               fade:false
+                                                           resolver:^(NSString *one) {}
+                                                           rejecter:^(NSString *one, NSString *two, NSError *three) {}];
+
+    [_taskQueue addObject:task];
+    [RNBootSplash shiftNextTask];
 }
 
 RCT_REMAP_METHOD(show,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,26 @@
 import { NativeModules } from "react-native";
 
 export type VisibilityStatus = "visible" | "hidden" | "transitioning";
-export type Config = { fade?: boolean };
+export type Config = { fade?: boolean; bootsplashName?: string };
 
 const NativeModule: {
-  show: (fade: boolean) => Promise<true>;
-  hide: (fade: boolean) => Promise<true>;
+  show: (fade: boolean, bootsplashName: string) => Promise<true>;
+  hide: (fade: boolean, bootsplashName: string) => Promise<true>;
   getVisibilityStatus: () => Promise<VisibilityStatus>;
 } = NativeModules.RNBootSplash;
 
 export function show(config: Config = {}): Promise<void> {
-  return NativeModule.show({ fade: false, ...config }.fade).then(() => {});
+  return NativeModule.show(
+    { fade: false, ...config }.fade,
+    config.bootsplashName ?? "global",
+  ).then(() => {});
 }
 
 export function hide(config: Config = {}): Promise<void> {
-  return NativeModule.hide({ fade: false, ...config }.fade).then(() => {});
+  return NativeModule.hide(
+    { fade: false, ...config }.fade,
+    config.bootsplashName ?? "global",
+  ).then(() => {});
 }
 
 export function getVisibilityStatus(): Promise<VisibilityStatus> {


### PR DESCRIPTION
We wan't the app to display the SplashScreen when sent to background

When done from react-native side, the app may not have time to correctly display the SplashScreen before being frozen by the OS, so we need to do it from the native side

On iOS the `UIApplicationWillResignActiveNotification` event is used so the SplashScreen can be displayed when the user starts to use the multi-task feature. We cannot use `UIApplicationDidEnterBackgroundNotification` as it occurs too late and the UI won't refresh in time

On Android the `onHostPause` event is used and corresponds to when the app is sent to background. When the user starts to use the multi-task feature nothing happens, this event only occurs when the user goes to the device's home or when switching app

Only displaying the SplashScreen is done on native side, the action of hiding it should be done in react-native side so we have better control on when to do it

The problem with that naïve implementation is that we don't have precise control of when we want to hide the SplashScreen because the app successfully started or because the app came back from background

One example that is problematic is:
- The app starts and display the SplashScreen
- The Home is loading
- The user briefly open the iOS multi-task screen and directly come back to the app
- The app detects that it became active and tries to hide the SplashScreen
- But the Home has not finished loading so it should not hide the SplashScreen

To prevent this a solution is to give a name to SplashScreens so we can ask to only hide the "background state" related SplashScreen and keep the one for Home displayed

The impact is that to hide the SplashScreen, all SplashScreen names should be hide

For now we need two SplashScreen:
- `global` corresponds to the main SplashScreen that is used to hide the app when something is loading
- `secure_background` corresponds to the SplashScreen used to hide the app's content when sent to background

> **Warning**
> On Android, when the app is sent to background, then it has a small amount of time to do work before being "deactivated" by the OS. So on slow devices, the UI may not show the splashscreen in time which would result of the app's content being still visible when app's is on background

Related PR: cozy/cozy-flagship-app#894