### PR TITLE
feat: init names with "global" (VO-197)

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -45,6 +45,10 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
   private static Status mStatus = Status.HIDDEN;
   private static boolean mIsAppInBackground = false;
 
+  static {
+    mBootsplashNames.add("global");
+  }
+
   public RNBootSplashModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactContext.addLifecycleEventListener(this);

--- a/ios/RNBootSplash.m
+++ b/ios/RNBootSplash.m
@@ -42,6 +42,12 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (void)initialize {
+    if (self == [RNBootSplash class]) {
+        _bootsplashNames = [NSMutableArray arrayWithObject:@"global"];
+    }
+}
+
 + (void)addBootsplashName:(NSString * _Nonnull)name {
   if ([_bootsplashNames indexOfObject:name] == NSNotFound) {
     [_bootsplashNames addObject:name];
@@ -64,7 +70,6 @@ RCT_EXPORT_MODULE();
   _status = RNBootSplashStatusVisible;
   _storyboardName = storyboardName;
   _taskQueue = [[NSMutableArray alloc] init];
-  _bootsplashNames = [[NSMutableArray alloc] init];
 
   UIStoryboard *storyboard = [UIStoryboard storyboardWithName:_storyboardName bundle:nil];
   [_rootView setLoadingView:[[storyboard instantiateInitialViewController] view]];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bootsplash",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "MIT",
   "description": "Display a bootsplash on your app starts. Hide it when you want.",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",


### PR DESCRIPTION
this will avoid scenarios where a named screen
hides "global" on app launch